### PR TITLE
Fix some bugs

### DIFF
--- a/gringotts/api/v2/product.py
+++ b/gringotts/api/v2/product.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import datetime
-import json
 
 from oslo_config import cfg
 import pecan

--- a/gringotts/api/v2/project.py
+++ b/gringotts/api/v2/project.py
@@ -1,5 +1,4 @@
 import pecan
-import wsme
 import datetime
 import itertools
 
@@ -18,9 +17,7 @@ from gringotts import utils as gringutils
 from gringotts.api.v2 import models
 from gringotts.db import models as db_models
 from gringotts.services import keystone
-from gringotts.checker import notifier
 from gringotts.openstack.common import log
-from gringotts.openstack.common import uuidutils
 from gringotts.openstack.common import timeutils
 
 

--- a/gringotts/api/v2/resource.py
+++ b/gringotts/api/v2/resource.py
@@ -1,5 +1,3 @@
-import pecan
-import wsme
 import itertools
 
 from oslo_config import cfg

--- a/gringotts/api/v2/sub.py
+++ b/gringotts/api/v2/sub.py
@@ -1,25 +1,13 @@
-import calendar
 import pecan
-import wsme
-import datetime
-import decimal
 
 from pecan import rest
 from pecan import request
 from wsmeext.pecan import wsexpose
 from wsme import types as wtypes
 
-from oslo_config import cfg
-
-from gringotts import exception
-from gringotts import utils as gringutils
-
 from gringotts.api import acl
 from gringotts.api.v2 import models
-from gringotts.db import models as db_models
 from gringotts.openstack.common import log
-from gringotts.openstack.common import timeutils
-from gringotts.openstack.common import uuidutils
 
 
 LOG = log.getLogger(__name__)

--- a/gringotts/db/sqlalchemy/api.py
+++ b/gringotts/db/sqlalchemy/api.py
@@ -360,7 +360,9 @@ class Connection(api.Connection):
                         new_seg = seg.as_dict()
                         new_seg['price'] = str(new_seg['price'])
                         new_segmented.append(new_seg)
-                    p_dict['unit_price'][key]['segmented'] = new_segmented
+                    p_dict['unit_price'][key]['segmented'] = \
+                        sorted(new_segmented, key=lambda p: p['count'],
+                               reverse=True)
             p_dict['unit_price'] = jsonutils.dumps(p_dict['unit_price'])
         except KeyError:
             LOG.error("The unit_price lack of some key words.")
@@ -2192,7 +2194,7 @@ class Connection(api.Connection):
                 account = model_query(
                     context, sa_models.Account, session=session).\
                     filter_by(user_id=project.user_id).\
-                    one()
+                    with_lockmode('update').one()
             except NoResultFound:
                 LOG.error('Could not find the account: %s' % order.project_id)
                 raise exception.AccountNotFound(project_id=order.project_id)

--- a/gringotts/middleware/cinder.py
+++ b/gringotts/middleware/cinder.py
@@ -32,7 +32,7 @@ class SizeItem(base.ProductItem):
         if 'volume' in body:
             return body['volume']['size']
         elif 'snapshot' in body:
-            volume = cinder.volume_get(body['snapshot']['volume_id'])
+            volume = cinder.snapshot_get(body['snapshot']['volume_id'])
             return volume.size
 
 
@@ -118,7 +118,7 @@ class CinderBillingProtocol(base.BillingProtocol):
             self.gclient.resize_resource_order(order_id,
                                                quantity=quantity,
                                                resource_type=resource_type)
-        except Exception as e:
+        except Exception:
             msg = "Unbale to resize the order: %s" % order_id
             LOG.exception(msg)
             return False, self._reject_request_500(env, start_response)

--- a/gringotts/middleware/keystone.py
+++ b/gringotts/middleware/keystone.py
@@ -145,8 +145,8 @@ class KeystoneBillingProtocol(object):
     def parse_user_result(self, body, result):
         users = []
         try:
-            for re in result:
-                user = jsonutils.loads(re)['user']
+            for r in result:
+                user = jsonutils.loads(r)['user']
                 users.append(User(
                     user_id=user['id'],
                     user_name=user['name'],
@@ -158,8 +158,8 @@ class KeystoneBillingProtocol(object):
     def parse_project_result(self, body, result):
         projects = []
         try:
-            for re in result:
-               project = jsonutils.loads(re)['project']
+            for r in result:
+               project = jsonutils.loads(r)['project']
                projects.append(Project(
                    project_id=project['id'],
                    project_name=project['name'],

--- a/gringotts/middleware/nova.py
+++ b/gringotts/middleware/nova.py
@@ -7,11 +7,9 @@ from gringotts import constants as const
 from gringotts import exception
 from gringotts.middleware import base
 from gringotts.openstack.common import jsonutils
-from gringotts.openstack.common import timeutils
 from gringotts.openstack.common import memorycache
 from gringotts.services import nova
 from gringotts.services import glance
-from gringotts import utils as gringutils
 
 LOG = logging.getLogger(__name__)
 

--- a/gringotts/price/pricing.py
+++ b/gringotts/price/pricing.py
@@ -1,10 +1,7 @@
 
-import six
-
 from decimal import Decimal
 
 from gringotts import exception
-from gringotts.openstack.common import jsonutils
 from gringotts import utils as gringutils
 
 
@@ -29,7 +26,7 @@ def calculate_segmented_price(quantity, price_list):
 
     q = int(quantity)
     total_price = quantize_decimal(0)
-    for p in price_list:
+    for p in sorted(price_list, key=lambda p: p['count'], reverse=True):
         if q > p['count']:
             total_price += (q - p['count']) * quantize_decimal(p['price'])
             q = p['count']

--- a/gringotts/services/cinder.py
+++ b/gringotts/services/cinder.py
@@ -117,6 +117,7 @@ def snapshot_get(snapshot_id, region_name=None):
     status = utils.transform_status(sp.status)
     return Snapshot(id=sp.id,
                     name=sp.display_name,
+                    size=sp.size,
                     status=status,
                     original_status=sp.status,
                     resource_type=const.RESOURCE_SNAPSHOT)


### PR DESCRIPTION
- When we caculate segmented price, we should sort the
  unit_price(type<list>), otherwise we will get wrong
  segmented price

- Now we get volume size from request body. but, if type
  is snapshot we should get size use cinder.snapshot_get()
  not cinder.volume_get()

- Fix some pep8 error.