### PR TITLE
Fix neutron loadbalancer update/delete bug

### DIFF
--- a/gringotts/middleware/neutron.py
+++ b/gringotts/middleware/neutron.py
@@ -78,6 +78,7 @@ class NeutronBillingProtocol(base.BillingProtocol):
             self.resource_regex,
             self.change_fip_ratelimit_regex,
             self.update_listener_regex,
+            self.delete_loadbalancer_regex,
         ]
         self.no_billing_resource_regexs = [
             self.delete_loadbalancer_regex,
@@ -151,7 +152,7 @@ class NeutronBillingProtocol(base.BillingProtocol):
         return False
 
     def delete_loadbalancer_action(self, method, path_info, body):
-        if method == 'PUT' \
+        if method == 'DELETE' \
             and self.delete_loadbalancer_regex.search(path_info):
             return True
         return False


### PR DESCRIPTION
This commit aimed to fix the delete loadbalancer funtion.
With this commit it can fix the following two bugs:
1. when update loadbalancer, met the error:
self.no_billing_resource_method[method_name](env, start_response,
ERROR oslo_middleware.catch_errors KeyError: 'put_lbaas/loadbalancers'
2. when delete the loadbalancer, met the error:
show failed (client error): loadbalancer None could not be found